### PR TITLE
file re-organization and enforce coding conventions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The RegERMs.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2014:
->  * Christoph Sawade
+>  * Christoph Sawade and contributors
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ regParam = 0.1
 model = optimize(svm, regParam)
 
 # make predictions and compute accuracy
-ybar = classify(model, X)
+ybar = predict(model, X)
 acc = mean(ybar .== y)
 
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
-Optim
+julia 0.3-
+StatsBase 0.6.0-
+Optim 0.3.1-

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 The following issues should be addressed (not ordered by priority):
+
 - propagate kernel parameters
 - cross-validation and use it if regularisation parameter is not provided
 - sparse representation of data

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -1,4 +1,3 @@
-export Loss, LogisticLoss, SquaredLoss, HingeLoss, value, values, deriv, derivs, value_and_deriv, tloss
 
 abstract Loss
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,48 +1,46 @@
-export Model, PrimalModel, DualModel, classify
-
 function Model(X::Matrix, y::Vector, kernel::Symbol=:linear)
-	n, m = size(X)
-	if m < n && kernel==:linear # learn primal model to reduce number of dimensions
-		w0 = vec(mean(X[y.==1,:],1).-mean(X[y.==-1,:]))
-		PrimalModel(w0), X
-	else
-		map = MercerMap(X, kernel)
-		X = apply(map)
-		w0 = vec(mean(X[y.==1,:],1).-mean(X[y.==-1,:]))
-		DualModel(w0, map), X
-	end
+    n, m = size(X)
+    if m < n && kernel==:linear # learn primal model to reduce number of dimensions
+        w0 = vec(mean(X[y.==1,:],1).-mean(X[y.==-1,:]))
+        PrimalModel(w0), X
+    else
+        map = MercerMap(X, kernel)
+        X = apply(map)
+        w0 = vec(mean(X[y.==1,:],1).-mean(X[y.==-1,:]))
+        DualModel(w0, map), X
+    end
 end
 
 ## Primal model
 
 type PrimalModel
-	w::Vector # weight vector of linear function
+    w::Vector # weight vector of linear function
 end
 
-classify(model::PrimalModel, X::Matrix) = sign(X*model.w)
+predict(model::PrimalModel, X::Matrix) = sign(X*model.w)
 
 # Pretty-print
 function Base.show(io::IO, model::PrimalModel)
-	println(io, "Primal Model")
-	println(io, repeat("-", length("Primal Model")))
-	println(io, "number of dimensions: $(length(model.w))")
+    println(io, "Primal Model")
+    println(io, repeat("-", length("Primal Model")))
+    println(io, "number of dimensions: $(length(model.w))")
 end
 
 ## Dual model
 
 # TOOD(cs): map should be immutable
 type DualModel
-	w::Vector 	   # weight vector of linear function
-	map::MercerMap # dual model is implemented via Mercer map
+    w::Vector      # weight vector of linear function
+    map::MercerMap # dual model is implemented via Mercer map
 end
 
-classify(model::DualModel, X::Matrix)  = sign(apply(model.map, X)*model.w)
+predict(model::DualModel, X::Matrix)  = sign(apply(model.map, X)*model.w)
 
 # Pretty-print
 function Base.show(io::IO, model::DualModel)
-	println(io, "Dual Model")
-	println(io, repeat("-", length("Dual Model")))
-	println(io, "number of dimensions: $(length(model.w))")
-	println(io, "number of examples:   $(size(model.map.K,1))")
-	println(io, "kernel function:      $(model.map.kernel)")
+    println(io, "Dual Model")
+    println(io, repeat("-", length("Dual Model")))
+    println(io, "number of dimensions: $(length(model.w))")
+    println(io, "number of examples:   $(size(model.map.K,1))")
+    println(io, "kernel function:      $(model.map.kernel)")
 end

--- a/src/models/logistic_regression.jl
+++ b/src/models/logistic_regression.jl
@@ -1,16 +1,14 @@
-export LogReg
-
 immutable LogReg <: RegERM
     X::Matrix       # n x m matrix of n m-dimensional training examples
     y::Vector       # 1 x n vector with training classes
     n::Int          # number of training examples
     m::Int          # number of features
-    kernel::Symbol 	# kernel function 
+    kernel::Symbol  # kernel function 
 end
 
 function LogReg(X::Matrix, y::Vector; kernel::Symbol=:linear)
-	check_arguments(X, y)
-	LogReg(X, y, size(X)..., kernel)
+    check_arguments(X, y)
+    LogReg(X, y, size(X)..., kernel)
 end
 
 methodname(::LogReg) = "Logistic Regression"

--- a/src/models/ridge_regression.jl
+++ b/src/models/ridge_regression.jl
@@ -1,16 +1,14 @@
-export RidgeReg
-
 immutable RidgeReg <: RegERM
     X::Matrix       # n x m matrix of n m-dimensional training examples
     y::Vector       # 1 x n vector with training classes
     n::Int          # number of training examples
     m::Int          # number of features
-    kernel::Symbol 	# kernel function
+    kernel::Symbol  # kernel function
 end
 
 function RidgeReg(X::Matrix, y::Vector; kernel::Symbol=:linear)
-	check_arguments(X, y)
-	RidgeReg(X, y, size(X)..., kernel)
+    check_arguments(X, y)
+    RidgeReg(X, y, size(X)..., kernel)
 end
 
 methodname(::RidgeReg) = "Linear Regression"
@@ -19,16 +17,16 @@ regularizer(::RidgeReg, w::Vector, λ::Float64) = L2reg(w, λ)
 
 # closed-form solution
 function optimize(RidgeReg::RidgeReg, λ::Float64; optimizer::Symbol=:closed_form)
-	if (λ <= 0)
-		throw(ArgumentError("Regularization parameter has to be positive"))
-	end
-	
-	if optimizer == :closed_form
-		y = RidgeReg.y
-		model, X = Model(RidgeReg.X, y, RidgeReg.kernel)
-		model.w = (X'*X + eye(RidgeReg.m)/λ)\X'*y
-		model
-	else
-		invoke(optimize, (RegERM, Float64, Symbol), RidgeReg, λ, optimizer)
-	end
+    if (λ <= 0)
+        throw(ArgumentError("Regularization parameter has to be positive"))
+    end
+    
+    if optimizer == :closed_form
+        y = RidgeReg.y
+        model, X = Model(RidgeReg.X, y, RidgeReg.kernel)
+        model.w = (X'*X + eye(RidgeReg.m)/λ)\X'*y
+        model
+    else
+        invoke(optimize, (RegERM, Float64, Symbol), RidgeReg, λ, optimizer)
+    end
 end

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -1,16 +1,14 @@
-export SVM, loss, regularizer
-
 immutable SVM <: RegERM
-    X::Matrix  		# n x m matrix of n m-dimensional training examples
-    y::Vector  		# 1 x n vector with training classes
-    n::Int     		# number of training examples
-    m::Int     		# number of features
-    kernel::Symbol 	# kernel function
+    X::Matrix       # n x m matrix of n m-dimensional training examples
+    y::Vector       # 1 x n vector with training classes
+    n::Int          # number of training examples
+    m::Int          # number of features
+    kernel::Symbol  # kernel function
 end
 
 function SVM(X::Matrix, y::Vector; kernel::Symbol=:linear)
-	check_arguments(X, y)
-	SVM(X, y, size(X)..., kernel)
+    check_arguments(X, y)
+    SVM(X, y, size(X)..., kernel)
 end
 
 methodname(::SVM) = "Support Vector Machine"

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -1,0 +1,43 @@
+
+abstract RegERM
+abstract RegressionSolver
+
+# FIX: could not use ``method`` as keyword directly due to ``invoke` in RidgeReg, see https://github.com/JuliaLang/julia/issues/7045
+optimize(method::RegERM, λ::Float64; optimizer::Symbol=:l_bfgs) = optimize(method, λ, optimizer)
+function optimize(method::RegERM, λ::Float64, optimizer::Symbol=:l_bfgs)
+    if (λ <= 0)
+        throw(ArgumentError("Regularization parameter has to be positive"))
+    end
+
+    # init model
+    model, X = Model(method.X, method.y, method.kernel)
+    y = method.y
+
+    if optimizer == :sgd
+        model.w = solve(method, SGDSolver(), X, y, model.w, λ)
+    elseif optimizer == :l_bfgs
+        model.w = solve(method, LBFGSSolver(), X, y, model.w, λ)
+    else
+        throw(ArgumentError("Unknown optimizer=$(optimizer)"))
+    end
+    model
+end
+
+function check_arguments(X::Matrix, y::Vector) 
+    (n, m) = size(X)
+    if (n != length(y))
+        throw(DimensionMismatch("Dimensions of X and y mismatch."))
+    end
+    if (sort(unique(y)) != [-1,1])
+        throw(ArgumentError("Class labels have to be either -1 or 1"))
+    end
+end
+
+# Pretty-print
+function Base.show(io::IO, model::RegERM)
+    println(io, "$(methodname(model))")
+    println(io, repeat("-", length(methodname(model))))
+    println(io, "number of examples:       $(model.n)")
+    println(io, "number of features:       $(model.m)")
+    println(io, "kernel function:          $(model.kernel)")
+end

--- a/src/regularizer.jl
+++ b/src/regularizer.jl
@@ -1,5 +1,3 @@
-export Regularizer, L2reg
-
 abstract Regularizer
 
 ## l2-regularizer
@@ -12,6 +10,7 @@ end
 function value(r::L2reg) 
     norm(r.w)^2 / (2 * r.λ)
 end
+
 function gradient(r::L2reg) 
     r.w / r.λ
 end

--- a/src/solvers/lbfgs.jl
+++ b/src/solvers/lbfgs.jl
@@ -1,16 +1,14 @@
-export LBFGSSolver
-
 type LBFGSSolver <: RegressionSolver end
 
 # TODO: λ should be a part of the regularizer and be handled at the model level (e.g., via automatic cross-validation if not provided)
 function solve(method::RegERM, ::LBFGSSolver, X::AbstractMatrix, y::AbstractVector, w0::AbstractVector, λ::Float64)
-	reg(w::Vector) = regularizer(method, w, λ)
-	# TODO: use tloss_and_gradient for efficiency
-	tloss_grad(w::Vector) = vec(sum(X.*derivs(loss(method), X*w, y), 1))
-	reg_grad(w::Vector) = gradient(reg(w))
-	
-	obj(w::Vector) = tloss(loss(method), X*w, y) + value(reg(w))
-	grad!(w::Vector, storage::Vector) = storage[:] = tloss_grad(w) + reg_grad(w)
+    reg(w::Vector) = regularizer(method, w, λ)
+    # TODO: use tloss_and_gradient for efficiency
+    tloss_grad(w::Vector) = vec(sum(X.*derivs(loss(method), X*w, y), 1))
+    reg_grad(w::Vector) = gradient(reg(w))
+    
+    obj(w::Vector) = tloss(loss(method), X*w, y) + value(reg(w))
+    grad!(w::Vector, storage::Vector) = storage[:] = tloss_grad(w) + reg_grad(w)
 
-	Optim.optimize(obj, grad!, w0, method=:l_bfgs, linesearch! = Optim.interpolating_linesearch!).minimum
+    Optim.optimize(obj, grad!, w0, method=:l_bfgs, linesearch! = Optim.interpolating_linesearch!).minimum
 end

--- a/src/solvers/sgd.jl
+++ b/src/solvers/sgd.jl
@@ -1,14 +1,12 @@
-export SGDSolver
-
 type SGDSolver <: RegressionSolver end
 
 # TODO: λ should be a part of the regularizer and be handled at the model level (e.g., via automatic cross-validation if not provided)
 function solve(method::RegERM, ::SGDSolver, X::AbstractMatrix, y::AbstractVector, w0::AbstractVector, λ::Float64)
-	loss_grad(w::Vector, i::Int) = vec(X[i,:]).*deriv(loss(method), (X[i,:]*w)[1], y[i])
-	reg_grad(w::Vector) = gradient(regularizer(method, w, λ)) / method.n
-	grad(w::Vector, i::Int) = loss_grad(w, i) + reg_grad(w)
+    loss_grad(w::Vector, i::Int) = vec(X[i,:]).*deriv(loss(method), (X[i,:]*w)[1], y[i])
+    reg_grad(w::Vector) = gradient(regularizer(method, w, λ)) / method.n
+    grad(w::Vector, i::Int) = loss_grad(w, i) + reg_grad(w)
 
-	sgd(grad, method.n, w0)
+    sgd(grad, method.n, w0)
 end
 
 # step size has to statisfy the conditions sum alpha^2 < inf and sum alpha = inf
@@ -17,13 +15,13 @@ sqrt_step_size(k::Int) = 1 / sqrt(k)
 lin_step_size(k::Int) = 1 / k
 
 function sgd{T}(grad::Function, 
-				n::Int, 
-				initial_x::Array{T};
-			 	iterations::Int=1000,
-			 	xtol::Real = 1e-8,
-			 	step_size::Function = sqrt_step_size)
+                n::Int, 
+                initial_x::Array{T};
+                iterations::Int=1000,
+                xtol::Real = 1e-8,
+                step_size::Function = sqrt_step_size)
 
-	# Maintain current state in x and previous state in x_previous
+    # Maintain current state in x and previous state in x_previous
     x, x_previous = copy(initial_x), copy(initial_x)
 
     # Count the total number of iterations
@@ -35,23 +33,23 @@ function sgd{T}(grad::Function,
     # Iterate until convergence
     converged = false
     while !converged && iteration < iterations
-    	# Increment the number of steps we've had to perform
+        # Increment the number of steps we've had to perform
         iteration += 1
 
-    	# randomly iterate over gradients
-		for i = randperm(n)
-			k += 1
+        # randomly iterate over gradients
+        for i = randperm(n)
+            k += 1
 
-			# Update step size
-			alpha = step_size(k)
+            # Update step size
+            alpha = step_size(k)
 
-        	# Update current solution
-			x = x_previous - alpha*grad(x_previous, i)
-		end
+            # Update current solution
+            x = x_previous - alpha*grad(x_previous, i)
+        end
 
-		converged = norm(x - x_previous) < xtol
-		
-		# Maintain a record of previous position
+        converged = norm(x - x_previous) < xtol
+        
+        # Maintain a record of previous position
         copy!(x_previous, x)
     end
     x

--- a/test/logistic_regression.jl
+++ b/test/logistic_regression.jl
@@ -11,7 +11,7 @@ y = [-1; -1; 1]
 @test_approx_eq_eps optimize(LogReg(X, y), 1.0, optimizer=:sgd).w [-0.16588135026949055,-0.840712964600344] 5e-2
 @test_approx_eq_eps optimize(LogReg(X, y), 10.0, optimizer=:sgd).w [-0.0745584919313508,-2.20259301054857] 5e-2
 model = optimize(LogReg(X, y), 10.0, optimizer=:sgd)
-@test classify(model, X) == [-1; -1; 1]
+@test predict(model, X) == [-1; -1; 1]
 show(IOBuffer(), LogReg(X, y))
 
 @test_throws DimensionMismatch LogReg(X', y) 

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -1,9 +1,9 @@
 eps = 1e-5
 # list of losses
 losslist = [
-	HingeLoss(),
-	LogisticLoss(),
-	SquaredLoss()
+    HingeLoss(),
+    LogisticLoss(),
+    SquaredLoss()
 ]
 
 fv, y = [2.; 4.; 0.], [-1; -1; 1]
@@ -18,24 +18,24 @@ expected_values(::SquaredLoss) = [4.5, 12.5, 0.5]
 expected_derivs(::SquaredLoss) = [3.0, 5.0, -1.0]
 
 for loss in losslist
-	print(" - ")
-	println(loss)
+    print(" - ")
+    println(loss)
 
-	# check values
-	@test_approx_eq_eps values(loss, fv, y) expected_values(loss) eps
-	for i in 1:3
-		@test_approx_eq_eps value(loss, fv[i], y[i]) expected_values(loss)[i] eps
-	end
-	@test_approx_eq_eps tloss(loss, fv, y) sum(expected_values(loss)) eps
+    # check values
+    @test_approx_eq_eps values(loss, fv, y) expected_values(loss) eps
+    for i in 1:3
+        @test_approx_eq_eps value(loss, fv[i], y[i]) expected_values(loss)[i] eps
+    end
+    @test_approx_eq_eps tloss(loss, fv, y) sum(expected_values(loss)) eps
 
-	# check derivatives
-	@test_approx_eq_eps derivs(loss, fv, y) expected_derivs(loss) eps
-	for i in 1:3
-		@test_approx_eq_eps deriv(loss, fv[i], y[i]) expected_derivs(loss)[i] eps
-	end
-	
-	# check values and derivatives
-	for i in 1:3
-		@test_approx_eq_eps [value_and_deriv(loss, fv[i], y[i])...] [expected_values(loss)[i], expected_derivs(loss)[i]] eps
-	end
+    # check derivatives
+    @test_approx_eq_eps derivs(loss, fv, y) expected_derivs(loss) eps
+    for i in 1:3
+        @test_approx_eq_eps deriv(loss, fv[i], y[i]) expected_derivs(loss)[i] eps
+    end
+    
+    # check values and derivatives
+    for i in 1:3
+        @test_approx_eq_eps [value_and_deriv(loss, fv[i], y[i])...] [expected_values(loss)[i], expected_derivs(loss)[i]] eps
+    end
 end

--- a/test/svm.jl
+++ b/test/svm.jl
@@ -13,7 +13,7 @@ y = [-1; -1; 1]
 @test_approx_eq_eps optimize(SVM(X, y), 1.0, optimizer=:sgd).w [1.34394e-16,-1.0] 5e-2
 @test_approx_eq_eps optimize(SVM(X, y), 10.0, optimizer=:sgd).w [1.34394e-16,-1.0] 5e-2
 model = optimize(SVM(X, y), 10.0, optimizer=:sgd)
-@test classify(model, X) == y
+@test predict(model, X) == y
 show(IOBuffer(), SVM(X, y))
 
 @test_throws DimensionMismatch SVM(X', y) 
@@ -36,4 +36,4 @@ show(IOBuffer(), model)
 X = [1 1; -1 -1;  1 -1; -1 1]
 y = [1; 1; -1; -1]
 model = optimize(SVM(X, y, kernel=:rbf), 0.1, optimizer=:l_bfgs)
-@test classify(model, X) == y
+@test predict(model, X) == y


### PR DESCRIPTION
No substantial changes. Most of the changes are for coding conventions:
- All `export`s should be placed in the package file, _i.e._ `RegERMs.jl`. So that people can look at that file and know what the package provides. (This is the convention of JuliaStats)
- `RegERMs` should not contain actual codes. It should only contain exports and a list of included source files. (I moved those codes in `RegERMs` to `optim.jl`)
- Use 4-space indentation instead of tabs. (This is the convention of Julia)
- Names that have already be provided by upstream packages (or Julia base) should be imported to extend (_e.g_, `optimize` and `predict`).
- I change `classify` to `predict` for models. 
