### PR TITLE
[WIP] Multinomial logistic regression

### DIFF
--- a/src/RegERMs.jl
+++ b/src/RegERMs.jl
@@ -4,47 +4,57 @@ using StatsBase
 using Optim
 
 import StatsBase: predict
-import Optim: optimize 
+import Optim: optimize
 
 ## Exports
 
-export 
+export
     # loss
-    Loss,           # abstract type for all kinds of loss
-    LogisticLoss,   # Type to represent logistic loss
-    SquaredLoss,    # Type to represent squared loss
-    HingeLoss,      # Type to represent hinge loss
+    Loss,                       # abstract type for all kinds of loss
+    LogisticLoss,               # Type to represent logistic loss
+    SquaredLoss,                # Type to represent squared loss
+    HingeLoss,                  # Type to represent hinge loss
+    MultinomialLogisticLoss,    # Type to represent multinomial logistic loss (soft max)
 
-    value,              # evaluate a single value
-    values,             # evaluate multiple values
-    deriv,              # evaluate a single derivative value
-    derivs,             # evaluate multiple derivative values
-    value_and_deriv,    # jointly evaluate function value and derivative
-    tloss,              # the total loss 
+    value,                      # evaluate a single value
+    values,                     # evaluate multiple values
+    deriv,                      # evaluate a single derivative value
+    derivs,                     # evaluate multiple derivative values
+    gradient,                   # evaluate a signle gradient
+    value_and_deriv,            # jointly evaluate function value and derivative
+    tloss,                      # the total loss
 
     # regularizer
-    Regularizer,    # abstract type for all kinds of regularizers
-    L2reg,          # Type to represent L2 regularizer
+    Regularizer,                # abstract type for all kinds of regularizers
+    L2reg,                      # Type to represent L2 regularizer
 
     # model
-    Model, 
-    PrimalModel, 
-    DualModel, 
-    predict,
+    Model,                      # automatic selection of model depending on regression and model type
+    RegressionModel,            # abstract type for all regression models
+    OrdinalModel,               # regression model for ordinal regression
+    BinomialModel,              # regression model for binomial classification
+    MultinomialModel,           # regression model for multinomial classification
+    predict,                    # evaluate a prediction
+
+    # regression function
+    RegressionFunction,         # abstract type for possible model functions
+    LinearRegressionFunction,   # linear model for regression
 
     # models
-    SVM,
-    RidgeReg,
-    LogReg,
+    SVM,                        # SVM model (binomial regression)
+    RidgeReg,                   # Ridge regression (ordinal regression)
+    BinomialLogReg,             # Logistic Regression (binomial regression)
+    MultinomialLogReg,          # Logistic Regression (multinomial regression)
 
     # solvers
-    LBFGSSolver,
-    SGDSolver,
+    LBFGSSolver,                # LBFGS solver
+    SGDSolver,                  # SGD solver
 
     # optim
-    RegERM, 
-    RegressionSolver, 
-    optimize
+    RegERM,                     # abstract type for learning models
+    RegressionSolver,           # solver for regression problems
+    objective,                  # evaluate the objective
+    optimize                    # optimize the objective
 
 ## Source files
 
@@ -52,6 +62,7 @@ export
 include("loss.jl")
 include("regularizer.jl")
 include("mercer_map.jl")   ## TODO: need some discussion about the API for this
+include("regression_function.jl")
 include("model.jl")
 include("optim.jl")
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -12,12 +12,22 @@ abstract MultinomialLoss <: NominalLoss
 
 # fall back
 value_and_deriv(l::Loss, fv::Real, y::Real) = (value(l, fv, y), deriv(l, fv, y))
+value_and_deriv(l::MultinomialLoss, fv::AbstractVector, y::Real) = (value(l, fv, y), deriv(l, fv, y))
 
 function tloss(l::Loss, fv::AbstractVector, y::AbstractVector)
     n = size(fv, 1)  # n is the number of samples
     s = 0.0
     for i = 1:n
         s += value(l, fv[i], y[i])
+    end
+    return s
+end
+
+function tloss(l::MultinomialLoss, fv::AbstractMatrix, y::AbstractVector)
+    n = size(fv, 1)  # n is the number of samples
+    s = 0.0
+    for i = 1:n
+        s += value(l, vec(fv[i,:]), y[i])
     end
     return s
 end
@@ -31,6 +41,15 @@ function values(l::Loss, fv::AbstractVector, y::AbstractVector)
     return v
 end
 
+function values(l::MultinomialLoss, fv::AbstractMatrix, y::AbstractVector)
+    n = size(fv, 1)  # n is the number of samples
+    v = zeros(n)
+    for i = 1:n
+        v[i] = value(l, vec(fv[i,:]), y[i])
+    end
+    return v
+end
+
 function derivs(l::Loss, fv::AbstractVector, y::AbstractVector)
     n = size(fv, 1)  # n is the number of samples
     dv = zeros(n)
@@ -40,31 +59,51 @@ function derivs(l::Loss, fv::AbstractVector, y::AbstractVector)
     return dv
 end
 
+function derivs(l::MultinomialLoss, fv::AbstractMatrix, y::AbstractVector)
+    n, k = size(fv)  # n is the number of samples
+    dv = zeros(n, k)
+    for i = 1:n
+        dv[i,:] = deriv(l, vec(fv[i,:]), y[i])
+    end
+    return dv
+end
+
 ## logistic loss
 
+# binomial
 type LogisticLoss <: BinomialLoss end
 
 value(l::LogisticLoss, fv::Real, y::Int) = -y*fv>34 ? -y*fv : log(1+exp(-y*fv))
 deriv(l::LogisticLoss, fv::Real, y::Int) = -y / (1 + exp(y*fv))
 
-function value_and_deriv(l::LogisticLoss, fv::Real, y::Int)
+function value_and_deriv(::LogisticLoss, fv::Real, y::Int)
     emyfv = exp(-y*fv)
     (fv>34 ? -y*fv : log(1+emyfv), -y * emyfv/(1+emyfv))
 end
+
+# multinomial (where fv are the decision values for k-1 difference vectors)
+# see http://en.wikipedia.org/wiki/Multinomial_logistic_regression#As_a_set_of_independent_binary_regressions
+type MultinomialLogisticLoss <: MultinomialLoss end
+
+value(::MultinomialLogisticLoss, fv::AbstractVector, y::Int) = log(1+sum(exp(fv)))-[fv, 0.0][y]
+
+# TODO(cs): rename to gradient
+deriv(l::MultinomialLogisticLoss, fv::Vector, y::Int) = exp(-value(l, fv, y))-(1:length(fv).==y)
 
 ## squared loss
 
 type SquaredLoss <: OrdinalLoss end
 
-value(l::SquaredLoss, fv::Real, y::Real) = (r = fv-y; 0.5 * r*r)
-deriv(l::SquaredLoss, fv::Real, y::Real) = fv-y
+value(::SquaredLoss, fv::Real, y::Real) = (r = fv-y; 0.5 * r*r)
+deriv(::SquaredLoss, fv::Real, y::Real) = fv-y
 
-value_and_deriv(l::SquaredLoss, fv::Real, y::Real) = (r=fv-y; (0.5 * r*r, r))
+value_and_deriv(::SquaredLoss, fv::Real, y::Real) = (r=fv-y; (0.5 * r*r, r))
+
 ## hinge loss
 
 type HingeLoss <: BinomialLoss end
 
-value(l::HingeLoss, fv::Real, y::Int) = max(0, 1-y*fv)
+value(::HingeLoss, fv::Real, y::Int) = max(0, 1-y*fv)
 deriv(l::HingeLoss, fv::Real, y::Int) = -y*(value(l, fv, y) > 0)
 
-value_and_deriv(l::HingeLoss, fv::Real, y::Int) = (h = max(0, 1-y*fv); (h, -y*(h>0)))
+value_and_deriv(::HingeLoss, fv::Real, y::Int) = (h = max(0, 1-y*fv); (h, -y*(h>0)))

--- a/src/models/logistic_regression.jl
+++ b/src/models/logistic_regression.jl
@@ -1,16 +1,38 @@
-immutable LogReg <: RegERM
-    X::Matrix       # n x m matrix of n m-dimensional training examples
-    y::Vector       # 1 x n vector with training classes
-    n::Int          # number of training examples
-    m::Int          # number of features
-    kernel::Symbol  # kernel function 
-end
-
-function LogReg(X::Matrix, y::Vector; kernel::Symbol=:linear)
-    check_arguments(X, y)
-    LogReg(X, y, size(X)..., kernel)
-end
+abstract LogReg <: RegERM
 
 methodname(::LogReg) = "Logistic Regression"
-loss(::LogReg) = LogisticLoss()
 regularizer(::LogReg, w::Vector, λ::Float64) = L2reg(w, λ)
+
+## binomial
+
+immutable BinomialLogReg <: LogReg
+    X::Matrix               # n x m matrix of n m-dimensional training examples
+    y::Vector               # 1 x n vector with training classes
+    n::Int                  # number of training examples
+    m::Int                  # number of features
+    kernel::Symbol          # kernel function
+    regression_type::Symbol # ordinal, binomial, multinomial
+end
+function BinomialLogReg(X::Matrix, y::Vector; kernel::Symbol=:linear)
+    check_arguments(X, y)
+    BinomialLogReg(X, y, size(X)..., kernel, :binomial)
+end
+
+loss(::BinomialLogReg) = LogisticLoss()
+
+## multinomial
+
+immutable MultinomialLogReg <: LogReg
+    X::Matrix               # n x m matrix of n m-dimensional training examples
+    y::Vector               # 1 x n vector with training classes
+    n::Int                  # number of training examples
+    m::Int                  # number of features
+    kernel::Symbol          # kernel function
+    regression_type::Symbol # ordinal, binomial, multinomial
+end
+function MultinomialLogReg(X::Matrix, y::Vector; kernel::Symbol=:linear)
+    #check_arguments(X, y)
+    MultinomialLogReg(X, y, size(X)..., kernel, :multinomial)
+end
+
+loss(::MultinomialLogReg) = MultinomialLogisticLoss()

--- a/src/models/ridge_regression.jl
+++ b/src/models/ridge_regression.jl
@@ -1,14 +1,15 @@
 immutable RidgeReg <: RegERM
-    X::Matrix       # n x m matrix of n m-dimensional training examples
-    y::Vector       # 1 x n vector with training classes
-    n::Int          # number of training examples
-    m::Int          # number of features
-    kernel::Symbol  # kernel function
+    X::Matrix               # n x m matrix of n m-dimensional training examples
+    y::Vector               # 1 x n vector with training classes
+    n::Int                  # number of training examples
+    m::Int                  # number of features
+    kernel::Symbol          # kernel function
+    regression_type::Symbol # ordinal, binomial, multinomial
 end
 
 function RidgeReg(X::Matrix, y::Vector; kernel::Symbol=:linear)
     check_arguments(X, y)
-    RidgeReg(X, y, size(X)..., kernel)
+    RidgeReg(X, y, size(X)..., kernel, :ordinal)
 end
 
 methodname(::RidgeReg) = "Linear Regression"
@@ -22,9 +23,9 @@ function optimize(RidgeReg::RidgeReg, λ::Float64; optimizer::Symbol=:closed_for
     end
     
     if optimizer == :closed_form
-        y = RidgeReg.y
-        model, X = Model(RidgeReg.X, y, RidgeReg.kernel)
-        model.w = (X'*X + eye(RidgeReg.m)/λ)\X'*y
+        y, X = RidgeReg.y, RidgeReg.X
+        model = Model(X, y, RidgeReg.regression_type, RidgeReg.kernel)
+        model.theta = (X'*X + eye(RidgeReg.m)/λ)\X'*y
         model
     else
         invoke(optimize, (RegERM, Float64, Symbol), RidgeReg, λ, optimizer)

--- a/src/models/svm.jl
+++ b/src/models/svm.jl
@@ -1,14 +1,15 @@
 immutable SVM <: RegERM
-    X::Matrix       # n x m matrix of n m-dimensional training examples
-    y::Vector       # 1 x n vector with training classes
-    n::Int          # number of training examples
-    m::Int          # number of features
-    kernel::Symbol  # kernel function
+    X::Matrix               # n x m matrix of n m-dimensional training examples
+    y::Vector               # 1 x n vector with training classes
+    n::Int                  # number of training examples
+    m::Int                  # number of features
+    kernel::Symbol          # kernel function
+    regression_type::Symbol # ordinal, binomial, multinomial
 end
 
 function SVM(X::Matrix, y::Vector; kernel::Symbol=:linear)
     check_arguments(X, y)
-    SVM(X, y, size(X)..., kernel)
+    SVM(X, y, size(X)..., kernel, :binomial)
 end
 
 methodname(::SVM) = "Support Vector Machine"

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -10,18 +10,20 @@ function optimize(method::RegERM, λ::Float64, optimizer::Symbol=:l_bfgs)
     end
 
     # init model
-    model, X = Model(method.X, method.y, method.kernel)
-    y = method.y
+    model = Model(method.X, method.y, method.regression_type, method.kernel)
 
     if optimizer == :sgd
-        model.w = solve(method, SGDSolver(), X, y, model.w, λ)
+        model.theta = solve(model, method, SGDSolver(), method.X, method.y, λ)
     elseif optimizer == :l_bfgs
-        model.w = solve(method, LBFGSSolver(), X, y, model.w, λ)
+        model.theta = solve(model, method, LBFGSSolver(), method.X, method.y, λ)
     else
         throw(ArgumentError("Unknown optimizer=$(optimizer)"))
     end
     model
 end
+
+objective(method::RegERM, model::RegressionModel, λ::Float64, theta::AbstractVector) =
+    tloss(loss(method), values(model, method.X, theta), method.y) + value(regularizer(method, theta, λ))
 
 function check_arguments(X::Matrix, y::Vector) 
     (n, m) = size(X)

--- a/src/regression_function.jl
+++ b/src/regression_function.jl
@@ -1,0 +1,13 @@
+
+abstract RegressionFunction
+
+# Linear predictive function
+
+type LinearRegressionFunction <: RegressionFunction
+end
+
+values(::LinearRegressionFunction, X::AbstractMatrix, w::Vector) = X*w
+gradient(::LinearRegressionFunction, X::AbstractMatrix, ::Vector) = X
+
+
+# TODO: Dual predictive function

--- a/test/logistic_regression.jl
+++ b/test/logistic_regression.jl
@@ -2,18 +2,27 @@
 srand(1)
 
 X = [1 1; 2 2;  1 -1]
+
+# binomial
 y = [-1; -1; 1]
+@test_approx_eq_eps optimize(BinomialLogReg(X, y), 0.1, optimizer=:l_bfgs).theta [-0.07276615319846116,-0.1680076736259885] 5e-5
+@test_approx_eq_eps optimize(BinomialLogReg(X, y), 1.0, optimizer=:l_bfgs).theta [-0.16588135026949055,-0.840712964600344] 5e-5
+@test_approx_eq_eps optimize(BinomialLogReg(X, y), 10.0, optimizer=:l_bfgs).theta [-0.0745584919313508,-2.20259301054857] 5e-5
 
-@test_approx_eq_eps optimize(LogReg(X, y), 0.1, optimizer=:l_bfgs).w [-0.07276615319846116,-0.1680076736259885] 5e-5
-@test_approx_eq_eps optimize(LogReg(X, y), 1.0, optimizer=:l_bfgs).w [-0.16588135026949055,-0.840712964600344] 5e-5
-@test_approx_eq_eps optimize(LogReg(X, y), 10.0, optimizer=:l_bfgs).w [-0.0745584919313508,-2.20259301054857] 5e-5
-@test_approx_eq_eps optimize(LogReg(X, y), 0.1, optimizer=:sgd).w [-0.07276615319846116,-0.1680076736259885] 5e-2
-@test_approx_eq_eps optimize(LogReg(X, y), 1.0, optimizer=:sgd).w [-0.16588135026949055,-0.840712964600344] 5e-2
-@test_approx_eq_eps optimize(LogReg(X, y), 10.0, optimizer=:sgd).w [-0.0745584919313508,-2.20259301054857] 5e-2
-model = optimize(LogReg(X, y), 10.0, optimizer=:sgd)
-@test predict(model, X) == [-1; -1; 1]
-show(IOBuffer(), LogReg(X, y))
+# TODO: should be moved to test/sgd.jl
+@test_approx_eq_eps optimize(BinomialLogReg(X, y), 0.1, optimizer=:sgd).theta [-0.07276615319846116,-0.1680076736259885] 5e-2
+@test_approx_eq_eps optimize(BinomialLogReg(X, y), 1.0, optimizer=:sgd).theta [-0.16588135026949055,-0.840712964600344] 5e-2
+@test_approx_eq_eps optimize(BinomialLogReg(X, y), 10.0, optimizer=:sgd).theta [-0.0745584919313508,-2.20259301054857] 5e-2
+model = optimize(BinomialLogReg(X, y), 10.0, optimizer=:sgd)
+@test predict(model, X) == y
+show(IOBuffer(), BinomialLogReg(X, y))
 
-@test_throws DimensionMismatch LogReg(X', y) 
-@test_throws ArgumentError LogReg(X, [3; 3; 2]) 
-@test_throws ArgumentError optimize(LogReg(X, y), 0.0) 
+@test_throws DimensionMismatch BinomialLogReg(X', y)
+@test_throws ArgumentError BinomialLogReg(X, [3; 3; 2])
+@test_throws ArgumentError optimize(BinomialLogReg(X, y), 0.0)
+
+# multinomial
+y = [1; 1; 2]
+method = MultinomialLogReg(X, y)
+model = optimize(method, 10.0, optimizer=:l_bfgs)
+@test predict(model, X) == y

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -1,9 +1,13 @@
 eps = 1e-5
 # list of losses
-losslist = [
+binomialLosses = [
     HingeLoss(),
     LogisticLoss(),
     SquaredLoss()
+]
+
+multinomialLosses = [
+    MultinomialLogisticLoss()
 ]
 
 fv, y = [2.; 4.; 0.; 40; 40], [-1; -1; 1; 1; -1]
@@ -13,11 +17,13 @@ expected_derivs(::HingeLoss) = [1.0, 1.0, -1.0, 0.0, 1.0]
 
 expected_values(::LogisticLoss) = [2.12693, 4.01815, 0.693147, 0.0, 40.0]
 expected_derivs(::LogisticLoss) = [0.88079, 0.98201,-0.5, 0.0, 1.0]
+expected_values(::MultinomialLogisticLoss) = expected_values(LogisticLoss())
+expected_derivs(::MultinomialLogisticLoss) = [1-0.88079, 1-0.98201,-0.5, 0.0, 1-1.0]
 
 expected_values(::SquaredLoss) = [4.5, 12.5, 0.5, 760.5,840.5]
 expected_derivs(::SquaredLoss) = [3.0, 5.0, -1.0, 39.0, 41.0]
 
-for loss in losslist
+for loss in binomialLosses
     print(" - ")
     println(loss)
 
@@ -38,4 +44,23 @@ for loss in losslist
     for i in 1:3
         @test_approx_eq_eps [value_and_deriv(loss, fv[i], y[i])...] [expected_values(loss)[i], expected_derivs(loss)[i]] eps
     end
+end
+
+# multinomial version for k=2 should be identical to binomial loss
+fv_mul, y_mul = fv'', int((-y+3)/2)
+for loss in multinomialLosses
+    loss = multinomialLosses[1]
+    print(" - ")
+    println(loss)
+
+    # check values
+    @test_approx_eq_eps values(loss, fv_mul, y_mul) expected_values(loss) eps
+    for i in 1:3
+        @test_approx_eq_eps value(loss, vec(fv_mul[i,:]), y_mul[i]) expected_values(loss)[i] eps
+    end
+    @test_approx_eq_eps tloss(loss, fv_mul, y_mul) sum(expected_values(loss)) eps
+
+    # check derivatives
+    @test_approx_eq_eps derivs(loss, fv_mul, y_mul) expected_derivs(loss) eps
+
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -1,0 +1,6 @@
+X = [1 1; 2 2; 1 -1]
+y = [1; 1; 2]
+
+model = Model(X, y, :multinomial)
+@test predict(model, X) == y
+@test values(model, X) == [3.0 6.0 -2.0]'

--- a/test/ridge_regression.jl
+++ b/test/ridge_regression.jl
@@ -4,15 +4,15 @@ srand(1)
 X = [1 1; 2 2;  1 -1]
 y = [-1; -1; 1]
 
-@test_approx_eq_eps optimize(RidgeReg(X, y), 0.1, optimizer=:closed_form).w [-0.0666666666666667,-0.23333333333333334] 1e-5
-@test_approx_eq_eps optimize(RidgeReg(X, y), 1.0, optimizer=:closed_form).w [0.06060606060606055,-0.606060606060606] 1e-5
-@test_approx_eq_eps optimize(RidgeReg(X, y), 10.0, optimizer=:closed_form).w [0.1791607732201792,-0.7732201791607733] 1e-5
-@test_approx_eq_eps optimize(RidgeReg(X, y), 0.1, optimizer=:sgd).w [-0.0666666666666667,-0.23333333333333334] 5e-2
-@test_approx_eq_eps optimize(RidgeReg(X, y), 1.0, optimizer=:sgd).w [0.06060606060606055,-0.606060606060606] 5e-2
-@test_approx_eq_eps optimize(RidgeReg(X, y), 10.0, optimizer=:sgd).w [0.1791607732201792,-0.7732201791607733] 5e-2
-@test_approx_eq_eps optimize(RidgeReg(X, y), 0.1, optimizer=:l_bfgs).w [-0.0666666666666667,-0.23333333333333334] 1e-5
-@test_approx_eq_eps optimize(RidgeReg(X, y), 1.0, optimizer=:l_bfgs).w [0.06060606060606055,-0.606060606060606] 1e-5
-@test_approx_eq_eps optimize(RidgeReg(X, y), 10.0, optimizer=:l_bfgs).w [0.1791607732201792,-0.7732201791607733] 1e-5
+@test_approx_eq_eps optimize(RidgeReg(X, y), 0.1, optimizer=:closed_form).theta [-0.0666666666666667,-0.23333333333333334] 1e-5
+@test_approx_eq_eps optimize(RidgeReg(X, y), 1.0, optimizer=:closed_form).theta [0.06060606060606055,-0.606060606060606] 1e-5
+@test_approx_eq_eps optimize(RidgeReg(X, y), 10.0, optimizer=:closed_form).theta [0.1791607732201792,-0.7732201791607733] 1e-5
+@test_approx_eq_eps optimize(RidgeReg(X, y), 0.1, optimizer=:sgd).theta [-0.0666666666666667,-0.23333333333333334] 5e-2
+@test_approx_eq_eps optimize(RidgeReg(X, y), 1.0, optimizer=:sgd).theta [0.06060606060606055,-0.606060606060606] 5e-2
+@test_approx_eq_eps optimize(RidgeReg(X, y), 10.0, optimizer=:sgd).theta [0.1791607732201792,-0.7732201791607733] 5e-2
+@test_approx_eq_eps optimize(RidgeReg(X, y), 0.1, optimizer=:l_bfgs).theta [-0.0666666666666667,-0.23333333333333334] 1e-5
+@test_approx_eq_eps optimize(RidgeReg(X, y), 1.0, optimizer=:l_bfgs).theta [0.06060606060606055,-0.606060606060606] 1e-5
+@test_approx_eq_eps optimize(RidgeReg(X, y), 10.0, optimizer=:l_bfgs).theta [0.1791607732201792,-0.7732201791607733] 1e-5
 show(IOBuffer(), RidgeReg(X, y))
 
 @test_throws DimensionMismatch RidgeReg(X', y) 

--- a/test/svm.jl
+++ b/test/svm.jl
@@ -6,34 +6,16 @@ srand(1)
 X = [1 1; 2 2;  1 -1]
 y = [-1; -1; 1]
 
-@test_approx_eq_eps optimize(SVM(X, y), 0.1, optimizer=:l_bfgs).w [-0.1499984861841396,-0.3499984861803246] 1e-5
-@test_approx_eq_eps optimize(SVM(X, y), 1.0, optimizer=:l_bfgs).w [1.34394e-16,-1.0] 1e-5
-@test_approx_eq_eps optimize(SVM(X, y), 10.1, optimizer=:l_bfgs).w [1.34394e-16,-1.0] 1e-5
-@test_approx_eq_eps optimize(SVM(X, y), 0.1, optimizer=:sgd).w [-0.1499984861841396,-0.3499984861803246] 5e-2
-@test_approx_eq_eps optimize(SVM(X, y), 1.0, optimizer=:sgd).w [1.34394e-16,-1.0] 5e-2
-@test_approx_eq_eps optimize(SVM(X, y), 10.0, optimizer=:sgd).w [1.34394e-16,-1.0] 5e-2
+@test_approx_eq_eps optimize(SVM(X, y), 0.1, optimizer=:l_bfgs).theta [-0.1499984861841396,-0.3499984861803246] 1e-5
+@test_approx_eq_eps optimize(SVM(X, y), 1.0, optimizer=:l_bfgs).theta [1.34394e-16,-1.0] 1e-5
+@test_approx_eq_eps optimize(SVM(X, y), 10.1, optimizer=:l_bfgs).theta [1.34394e-16,-1.0] 1e-5
+@test_approx_eq_eps optimize(SVM(X, y), 0.1, optimizer=:sgd).theta [-0.1499984861841396,-0.3499984861803246] 5e-2
+@test_approx_eq_eps optimize(SVM(X, y), 1.0, optimizer=:sgd).theta [1.34394e-16,-1.0] 5e-2
+@test_approx_eq_eps optimize(SVM(X, y), 10.0, optimizer=:sgd).theta [1.34394e-16,-1.0] 5e-2
 model = optimize(SVM(X, y), 10.0, optimizer=:sgd)
+
 @test predict(model, X) == y
 show(IOBuffer(), SVM(X, y))
 
 @test_throws DimensionMismatch SVM(X', y) 
-@test_throws ArgumentError SVM(X, [3; 3; 2]) 
-
-# check automatic selection of model 
-X = [1 1; -1 -1;  1 -1; -1 1]
-y = [1; 1; -1; -1]
-model = optimize(SVM(X, y), 10.0, optimizer=:sgd)
-@test isa(model, PrimalModel)
-show(IOBuffer(), model)
-
-X = [1 1 -1 0.1; 2 2 0.5 2;  1 -1 -0.1 0.1]
-y = [-1; -1; 1]
-model = optimize(SVM(X, y), 10.0, optimizer=:sgd)
-@test isa(model, DualModel)
-show(IOBuffer(), model)
-
-# check kernelized solution
-X = [1 1; -1 -1;  1 -1; -1 1]
-y = [1; 1; -1; -1]
-model = optimize(SVM(X, y, kernel=:rbf), 0.1, optimizer=:l_bfgs)
-@test predict(model, X) == y
+@test_throws ArgumentError SVM(X, [3; 3; 2])


### PR DESCRIPTION
This is an example to clarify the structure of RegERMs (e.g., losses).

**Implement multinomial logistic regression**: need some more testing

**Structural changes**
- introduce abstract `MultinomialLoss`
- add `regression_function.jl` in addition to `model.jl`: `model.jl` takes care of the
  type of the model (ordinal, binomial, multinomial) and provides
  appropriate gradients and evaluation, and predictions, whereas
  `regression_function.jl` allows the distinction between, e.g., kernelized and
  linear models.

**Minor**
- disabled Mercer map for focus
- rename `w` to `theta` in model layer

[1] http://en.wikipedia.org/wiki/Multinomial_logistic_regression#As_a_set_of_independent_binary_regressions
