### PR TITLE
Add some value_and_deriv methods, fix value for LogisticLoss when fv > 34

### DIFF
--- a/src/loss.jl
+++ b/src/loss.jl
@@ -44,16 +44,22 @@ end
 
 type LogisticLoss <: BinomialLoss end
 
-value(l::LogisticLoss, fv::Real, y::Int) = if fv>34 -y*fv else log(1+exp(-y*fv)) end
+value(l::LogisticLoss, fv::Real, y::Int) = fv>34 ? -y*fv : log(1+exp(-y*fv))
 deriv(l::LogisticLoss, fv::Real, y::Int) = -y / (1 + exp(y*fv))
+
+function value_and_deriv(l::LogisticLoss, fv::Real, y::Int)
+    emyfv = exp(-y*fv)
+    (fv>34 ? -y*fv : log(1+emyfv), -y * emyfv/(1+emyfv))
+end
 
 ## squared loss
 
 type SquaredLoss <: OrdinalLoss end
 
-value(l::SquaredLoss, fv::Real, y::Real) = 0.5 * (fv-y) * (fv-y)
+value(l::SquaredLoss, fv::Real, y::Real) = (r = fv-y; 0.5 * r*r)
 deriv(l::SquaredLoss, fv::Real, y::Real) = fv-y
 
+value_and_deriv(l::SquaredLoss, fv::Real, y::Real) = (r=fv-y; (0.5 * r*r, r))
 ## hinge loss
 
 type HingeLoss <: BinomialLoss end

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -39,3 +39,12 @@ for loss in losslist
         @test_approx_eq_eps [value_and_deriv(loss, fv[i], y[i])...] [expected_values(loss)[i], expected_derivs(loss)[i]] eps
     end
 end
+
+#Check LogisticLoss for special case when fv > 34
+println(" - LogisticLoss(), fv > 34")
+@test_approx_eq_eps value(LogisticLoss(), 40.0, 1) -40.0 eps
+@test_approx_eq_eps value(LogisticLoss(), 40.0, -1) 40.0 eps
+@test_approx_eq_eps deriv(LogisticLoss(), 40.0, 1)  0.0 eps
+@test_approx_eq_eps deriv(LogisticLoss(), 40.0, -1) 1.0 eps
+@test_approx_eq_eps [value_and_deriv(LogisticLoss(), 40.0, 1)...]  [-40.0, 0.0] eps
+@test_approx_eq_eps [value_and_deriv(LogisticLoss(), 40.0, -1)...] [40.0, 1.0] eps


### PR DESCRIPTION
`value` for `LogisticLoss` was returning `nothing` when `fv` was big because `if fv > 34 -y*fv else ...` was being parsed as `if (fv > 34 - y*fv) nothing else....`
